### PR TITLE
Allow notebook to run as the UID of a local user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ADD requirements.txt /tmp/requirements/requirements.txt
-RUN pip3 install -r /tmp/requirements/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements/requirements.txt
 
 EXPOSE 8888
 RUN mkdir -p /home/ds/notebooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,17 @@ FROM mtgupf/essentia:ubuntu16.04-python3
 ENV TERM=xterm
 ENV LANG C.UTF-8
 
-RUN apt-get update -y && apt-get install build-essential -y
+# Add Tini. Tini operates as a process subreaper for jupyter. This prevents
+# kernel crashes.
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
 
 ADD apt-packages.txt /tmp/apt-packages.txt
-RUN xargs -a /tmp/apt-packages.txt apt-get install -y
+
+RUN apt-get update \
+    && xargs -a /tmp/apt-packages.txt apt-get install -y \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD requirements.txt /tmp/requirements/requirements.txt
 RUN pip3 install -r /tmp/requirements/requirements.txt
@@ -22,11 +29,6 @@ ENV USER=ds
 VOLUME /home/ds/notebooks
 WORKDIR /home/ds/notebooks
 
-# Add Tini. Tini operates as a process subreaper for jupyter. This prevents
-# kernel crashes.
-ENV TINI_VERSION v0.6.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN chmod +x /usr/bin/tini
 
 ADD jupyter_notebook_config.json /home/ds/.jupyter/
 CMD ["tini", "--", "jupyter-notebook", "--allow-root", "--no-browser",  "--port",  "8888",  "--ip", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
 RUN chmod +x /usr/bin/tini
 
-ADD apt-packages.txt /tmp/apt-packages.txt
+COPY apt-packages.txt /tmp/
 
 RUN apt-get update \
     && xargs -a /tmp/apt-packages.txt apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
-ADD requirements.txt /tmp/requirements/requirements.txt
-RUN pip3 install --no-cache-dir -r /tmp/requirements/requirements.txt
+COPY requirements.txt /tmp/
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
 EXPOSE 8888
 
@@ -31,7 +31,7 @@ VOLUME /notebooks
 WORKDIR /notebooks
 
 USER mir
-ADD jupyter_notebook_config.json /home/mir/.jupyter/
+COPY --chown=mir:mir jupyter_notebook_config.json /home/mir/.jupyter/
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,19 @@ ADD requirements.txt /tmp/requirements/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements/requirements.txt
 
 EXPOSE 8888
-RUN mkdir -p /home/ds/notebooks
-ENV HOME=/home/ds
-ENV SHELL=/bin/bash
-ENV USER=ds
-VOLUME /home/ds/notebooks
-WORKDIR /home/ds/notebooks
 
+RUN adduser -q --gecos "" --disabled-password mir
 
-ADD jupyter_notebook_config.json /home/ds/.jupyter/
-CMD ["tini", "--", "jupyter-notebook", "--allow-root", "--no-browser",  "--port",  "8888",  "--ip", "0.0.0.0"]
+RUN mkdir -p /notebooks
+
+VOLUME /notebooks
+WORKDIR /notebooks
+
+USER mir
+ADD jupyter_notebook_config.json /home/mir/.jupyter/
+
+USER root
+
+ADD start.sh /usr/local/bin
+
+CMD ["start.sh", "tini", "-s", "--", "jupyter-notebook", "--allow-root", "--no-browser",  "--port",  "8888",  "--ip", "0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
+.PHONY: build upload all
+
+all: build push
+
 build:
 	docker build -t mtgupf/mir-toolbox .
 
 push:
 	docker push mtgupf/mir-toolbox
 
-all: build push
-
-
- .PHONY: build upload all

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
-# MIR-toolbox-docker 
+# MIR-toolbox-docker
 
-This project provides a docker image to run a jupyter notebook server with essentia, freesound-python and a set of python dependencies commonly used in Music Information Retrieval (MIR). 
+This project provides a docker image to run a jupyter notebook server with
+essentia, freesound-python and a set of python dependencies commonly used in
+Music Information Retrieval (MIR).
+
+## Building
+
+You can build the image by running
+
+    make build
+
+This will build the image and tag it as `mtgupf/mir-toolbox`.
+Alternatively, you can pull the latest version of the image from docker hub.
+
+## Running
+
+Run the image with no arguments to start a Notebook server as root:
+
+    docker run --rm -p 8888:8888 mtgupf/mir-toolbox
+
+You can access the notebook at http://localhost:8888, use the password **mir**
+to access it.
+
+If you want to access a notebook from your host machine, mount a volume pointing
+to `/notebooks` inside the container
+
+    docker run --rm -p 8888:8888 --mount type=bind,source=$(pwd),target=/notebooks mtgupf/mir-toolbox
+
+ensure that the source location in the `--mount` option is an absolute path.
+
+### Permissions
+
+On linux, running jupyter-notebook as root means that any new files that you
+create will be owned by root. To prevent this from happening, you can set an
+environment variable, `JUPYTER_USER_ID` to a UID which will be used to run
+the notebook in the container. You can set this to the UID of your local user:
+
+    docker run --rm -e JUPYTER_USER_ID=1001 -p 8888:8888 --mount type=bind,source=$(pwd),target=/notebooks mtgupf/mir-toolbox

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Run the image with no arguments to start a Notebook server as root:
     docker run --rm -p 8888:8888 mtgupf/mir-toolbox
 
 You can access the notebook at http://localhost:8888, use the password **mir**
-to access it.
+to log in.
 
 If you want to access a notebook from your host machine, mount a volume pointing
 to `/notebooks` inside the container
 
     docker run --rm -p 8888:8888 --mount type=bind,source=$(pwd),target=/notebooks mtgupf/mir-toolbox
 
-ensure that the source location in the `--mount` option is an absolute path.
+ensure that the `source` location in the `--mount` option is an absolute path.
 
 ### Permissions
 
@@ -36,4 +36,4 @@ create will be owned by root. To prevent this from happening, you can set an
 environment variable, `JUPYTER_USER_ID` to a UID which will be used to run
 the notebook in the container. You can set this to the UID of your local user:
 
-    docker run --rm -e JUPYTER_USER_ID=1001 -p 8888:8888 --mount type=bind,source=$(pwd),target=/notebooks mtgupf/mir-toolbox
+    docker run --rm -e JUPYTER_USER_ID=$(id -u) -p 8888:8888 --mount type=bind,source=$(pwd),target=/notebooks mtgupf/mir-toolbox

--- a/apt-packages.txt
+++ b/apt-packages.txt
@@ -1,6 +1,3 @@
-python-pip
-python
-python-dev
 python3
 python3-dev
 python3-pip
@@ -16,7 +13,6 @@ libxslt1-dev
 libreadline6
 libreadline6-dev
 build-essential
-curl
 libjpeg8
 libjpeg8-dev
 libfreetype6
@@ -26,10 +22,10 @@ openssl
 libssl-dev
 pkg-config
 libffi-dev
-python-pip
 software-properties-common
 apt-transport-https
 ca-certificates
 curl
 wget
 nano
+sudo

--- a/apt-packages.txt
+++ b/apt-packages.txt
@@ -28,4 +28,4 @@ ca-certificates
 curl
 wget
 nano
-sudo
+gosu

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ music21
 networkx
 requests
 beautifulsoup4
--e git+http://github.com/MTG/freesound-python.git#egg=freesound-python
+-e git+https://github.com/MTG/freesound-python.git#egg=freesound-python
 -e git+https://github.com/craffel/mir_eval.git#egg=mir_eval
 -e git+https://github.com/MTG/pycompmusic.git#egg=compmusic

--- a/start.sh
+++ b/start.sh
@@ -18,7 +18,7 @@ if [[ -v JUPYTER_USER_ID && $JUPYTER_USER_ID != 0 ]]; then
     echo Set mir UID to: $JUPYTER_USER_ID
     usermod -u $JUPYTER_USER_ID mir
 
-    exec sudo -E -H -u mir $cmd
+    exec gosu mir $cmd
 else
     exec $cmd
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Based on start.sh from Jupyter Hub
+
+set -e
+
+if [ $# -eq 0 ]; then
+    cmd=bash
+else
+    cmd=$*
+fi
+
+if [[ $(id -u) != 0 ]]; then
+    echo Must run start.sh as root
+    exit 1
+fi
+
+if [[ -v JUPYTER_USER_ID && $JUPYTER_USER_ID != 0 ]]; then
+    echo Set mir UID to: $JUPYTER_USER_ID
+    usermod -u $JUPYTER_USER_ID mir
+
+    exec sudo -E -H -u mir $cmd
+else
+    exec $cmd
+fi
+


### PR DESCRIPTION
When running jupyter as the root user, file operations are done as root. This means that any time a file is written on linux, it will be owned as root instead of by the current user.
Make some changes to allow the notebook to run as any local userid.

Also clean up some package installation steps which left behind additional cache files.